### PR TITLE
Fix validation action to not run when pushing to main

### DIFF
--- a/.github/workflows/terraform_validate.yaml
+++ b/.github/workflows/terraform_validate.yaml
@@ -2,7 +2,7 @@
 name: Validate Configuration
 on:
   push:
-    branches_ignore:
+    branches-ignore:
       - main
   pull_request:
     branches:


### PR DESCRIPTION
Terraform validation is already run in the actions performed when applying the configuration.
The validation specific step was intended for pushing to branches and for checking pull requests (PR). Unfortunately the yaml was slightly incorrect so after merging the PR it ran both the validation and the apply actions.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore