### PR TITLE
Revert "[EAHW-2122] Add Timecard Repo"

### DIFF
--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -24,9 +24,6 @@ locals {
     },
     "callisto-ui-nginx" : {
       "checks" : local.checks.drone
-    },
-    "callisto-timecard-restapi" : {
-      "checks" : local.checks.drone
     }
     "callisto-jparest" : {
       "checks" : local.checks.drone


### PR DESCRIPTION
Reverts UKHomeOffice/callisto-build-github#10

Part of an attempt to try and determine the root cause of the terraform apply failure: https://github.com/UKHomeOffice/callisto-build-github/actions/runs/2775390502