### PR TITLE
remove callisto test repositories

### DIFF
--- a/terraform/repositories.tf
+++ b/terraform/repositories.tf
@@ -7,12 +7,6 @@ locals {
   }
 
   repositories = {
-    "callisto-test-1" : {
-      "checks" : local.checks.drone
-    },
-    "callisto-test-2" : {
-      "checks" : local.checks.drone
-    },
     "callisto-build-github" : {
       "checks" : ["terraform-validate"]
     },


### PR DESCRIPTION
This PR removes callisto-test-1 & callisto-test-2.
The repo's have been deleted and are now causing the Github action to fail.