### PR TITLE
Add callisto admins to repositories

### DIFF
--- a/.github/workflows/terraform_validate.yaml
+++ b/.github/workflows/terraform_validate.yaml
@@ -33,3 +33,8 @@ jobs:
     - name: Terraform Format
       id: fmt
       run: terraform fmt -check -recursive
+
+    - name: Terraform Plan
+      if: github.event_name == 'pull_request'
+      id: plan
+      run: terraform plan

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,7 +28,7 @@ resource "github_team_repository" "callisto_repos" {
   for_each   = module.repository
   team_id    = data.github_team.callisto.id
   repository = each.value.name
-  permission = "push"
+  permission = "maintain"
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,7 +28,7 @@ resource "github_team_repository" "callisto_repos" {
   for_each   = module.repository
   team_id    = data.github_team.callisto.id
   repository = each.value.name
-  permission = "maintain"
+  permission = "push"
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,4 +31,13 @@ resource "github_team_repository" "callisto_repos" {
   permission = "push"
 }
 
+data "github_team" "callisto_admins" {
+  slug = "callisto-admins"
+}
 
+resource "github_team_repository" "callisto_admin_repos" {
+  for_each   = module.repository
+  team_id    = data.github_team.callisto_admins.id
+  repository = each.value.name
+  permission = "admin"
+}


### PR DESCRIPTION
Give Callisto-Admins admin access to repositories.
Change also includes adding terraform plan step on PRs so that changes can be reviewd. (N.B. generated plan is still not used in the apply at the moment)